### PR TITLE
(refactor): update chaos experiment and sample engine CRs

### DIFF
--- a/charts/chaostoolkit/k8-pod-delete/engine.yaml
+++ b/charts/chaostoolkit/k8-pod-delete/engine.yaml
@@ -8,16 +8,11 @@ spec:
     appns: 'default'
     applabel: 'app=nginx'
     appkind: 'deployment'
-  # It can be true/false
   annotationCheck: 'true'
-  # It can be active/stop
   engineState: 'active'
-  #ex. values: ns1:name=percona,ns2:run=nginx
-  auxiliaryAppInfo: ''
   chaosServiceAccount: k8-pod-delete-sa
   monitoring: false
-  # It can be delete/retain
-  jobCleanUpPolicy: 'delete'
+  jobCleanUpPolicy: 'retain'
   experiments:
     - name: k8-pod-delete
       spec:
@@ -33,4 +28,4 @@ spec:
             - name: APP_ENDPOINT
               value: 'localhost'
             - name: FILE
-              value: 'experiment.json'
+              value: 'pod-app-kill-count.json'

--- a/charts/chaostoolkit/k8-pod-delete/experiment.yaml
+++ b/charts/chaostoolkit/k8-pod-delete/experiment.yaml
@@ -30,31 +30,30 @@ spec:
           - "patch"
           - "update"
           - "delete"
-      - apiGroups:
-          - ""
-        resources: 
-          - "nodes"
-        verbs :
-          - "get"
-          - "list"
-    image: "litmuschaos/chaostolkit:latest"
+    image: "litmuschaos/chaostoolkit:latest"
     args:
     - -c
-    - python k8_wrapper.py; exit 0
+    - python /app/data/k8_wrapper.py; exit 0
     command:
     - /bin/bash
     env:
+    - name: CHAOSTOOLKIT_IN_POD
+      value: 'true'
+
+    - name: FILE
+      value: 'pod-app-kill-count.json'
 
     - name: NAME_SPACE
-      value: 'default'
+      value: ''
 
     - name: LABEL_NAME
-      value: 'nginx'
+      value: ''
 
     - name: APP_ENDPOINT
-      value: 'localhost'
+      value: ''
 
-    - name: LIB
-      value: ''    
+    - name: PERCENTAGE
+      value: '50'
+
     labels:
       name: k8-pod-delete

--- a/charts/chaostoolkit/k8-pod-delete/k8-pod-delete.chartserviceversion.yaml
+++ b/charts/chaostoolkit/k8-pod-delete/k8-pod-delete.chartserviceversion.yaml
@@ -11,8 +11,7 @@ metadata:
 spec:
   displayName: k8-pod-delete
   categoryDescription: |
-    K8 Pod delete contains chaos to disrupt state of kubernetes resources. Experiments can inject random pod delete failures against specified application.
- 
+    K8 Pod delete contains chaos to disrupt state of kubernetes resources. It uses chaostoolkit to inject random pod delete failures against specified applications
   keywords:
     - Kubernetes
     - State 
@@ -31,7 +30,7 @@ spec:
     - name: Documentation
       url: https://docs.litmuschaos.io/docs/k8-pod-delete/
     - name: Video
-      url: https://www.youtube.com/watch?v=X3JvY_58V9A
+      url: '' 
   icon:
     - url: 
       mediatype: ""


### PR DESCRIPTION
- Makes minor enhancements to the chart/experiment CRs. 

   - Updates default chaos experiment json to  `pod-app-kill-count.json` 
   - Uses a jobCleanUpPolicy of `retain` until the experiment matures, so that logs can be captured immediately if needed
   - Updates path of experiment json inside chaostoolkit container
   - Populates default values for experiment tunables like experiment JSON filename, percentage kill & mode of execution in chaostoolkit_in_pod. Leaves the instance specific info (i.e., app info such as namespace, labels) empty to be overridden as mandatory params from the chaosengine
   - Minor changes to the CSV description to mention use of chaostoolkit




Signed-off-by: ksatchit <karthik.s@mayadata.io>